### PR TITLE
用RFC 5987标准解决文件下载中文文件名乱码

### DIFF
--- a/src/main/java/com/excel/poi/ExcelBoot.java
+++ b/src/main/java/com/excel/poi/ExcelBoot.java
@@ -17,6 +17,7 @@
 package com.excel.poi;
 
 import com.excel.poi.common.Constant;
+import com.excel.poi.common.WebFilenameUtils;
 import com.excel.poi.entity.ExcelEntity;
 import com.excel.poi.excel.ExcelReader;
 import com.excel.poi.excel.ExcelWriter;
@@ -193,7 +194,7 @@ public class ExcelBoot {
             try {
                 verifyResponse();
                 sxssfWorkbook = commonSingleSheet(param, exportFunction);
-                download(sxssfWorkbook, httpServletResponse, URLEncoder.encode(fileName + ".xlsx", "UTF-8"));
+                download(sxssfWorkbook, httpServletResponse, fileName + ".xlsx");
             } finally {
                 if (sxssfWorkbook != null) {
                     sxssfWorkbook.close();
@@ -273,7 +274,7 @@ public class ExcelBoot {
             try {
                 verifyResponse();
                 sxssfWorkbook = commonMultiSheet(param, exportFunction);
-                download(sxssfWorkbook, httpServletResponse, URLEncoder.encode(fileName + ".xlsx", "UTF-8"));
+                download(sxssfWorkbook, httpServletResponse, fileName + ".xlsx");
             } finally {
                 if (sxssfWorkbook != null) {
                     sxssfWorkbook.close();
@@ -352,7 +353,7 @@ public class ExcelBoot {
                 ExcelEntity excelMapping = ExcelMappingFactory.loadExportExcelClass(excelClass, fileName);
                 ExcelWriter excelWriter = new ExcelWriter(excelMapping, pageSize, rowAccessWindowSize, recordCountPerSheet, openAutoColumWidth);
                 sxssfWorkbook = excelWriter.generateTemplateWorkbook();
-                download(sxssfWorkbook, httpServletResponse, URLEncoder.encode(fileName + ".xlsx", "UTF-8"));
+                download(sxssfWorkbook, httpServletResponse, fileName + ".xlsx");
             } finally {
                 if (sxssfWorkbook != null) {
                     sxssfWorkbook.close();
@@ -432,7 +433,7 @@ public class ExcelBoot {
         OutputStream out = response.getOutputStream();
         response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
         response.setHeader("Content-disposition",
-                String.format("attachment; filename=%s", filename));
+                WebFilenameUtils.disposition(filename));
         if (null != out) {
             wb.write(out);
             out.flush();

--- a/src/main/java/com/excel/poi/common/WebFilenameUtils.java
+++ b/src/main/java/com/excel/poi/common/WebFilenameUtils.java
@@ -1,0 +1,36 @@
+package com.excel.poi.common;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.UnsupportedEncodingException;
+
+/**根据RFC 5987规范生成disposition值, 解决浏览器兼容以及中文乱码问题
+ * @author BiLuohen
+ * @date 6/25/2019
+ */
+public class WebFilenameUtils {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WebFilenameUtils.class);
+
+    private static final String DISPOSITION_FORMAT = "attachment; filename=\"%s\"; filename*=utf-8''%s";
+
+    /**
+     * 未编码文件名转Content-Disposition值
+     *
+     * @param filename 未编码的文件名(包含文件后缀)
+     * @return Content-Disposition值
+     */
+    public static String disposition(String filename) {
+        String codedFilename = filename;
+        try {
+            if (!StringUtil.isBlank(filename)) {
+                codedFilename = java.net.URLEncoder.encode(filename, "UTF-8");
+            }
+        } catch (UnsupportedEncodingException e) {
+            LOGGER.error("不支持的编码:", e);
+        }
+        return String.format(DISPOSITION_FORMAT, codedFilename, codedFilename);
+
+    }
+}


### PR DESCRIPTION
原方案对浏览器兼容性较差, 容易出现中文乱码, 新方案采用RFC5987标准实现, 可实现对不同浏览器的兼容问题, 而且根据user-agent判断浏览器类型